### PR TITLE
Add analog movement control

### DIFF
--- a/src/crafty.gamepad.js
+++ b/src/crafty.gamepad.js
@@ -200,8 +200,8 @@
                 this._speedOnAxes[id] = newSpeed;
                 if (this._axesPressed.indexOf(id) === -1) {
                   this._axesPressed.push(id);
+                  this.trigger('NewDirection', this._movement);
                 }
-                this.trigger('NewDirection', this._movement);
             } else {
                 for (var i = 0; i < this._axesPressed.length; i++) {
                     var ap = this._axesPressed[i];


### PR DESCRIPTION
Make use of the fine touches of the analog stick.

Moving the stick halfway will make use of half of the maximum speed. Tested with a PS3 controller.

The analog movement control must be explicitly enabled by using:

```
Crafty.e('GamepadMultiway').gamepadMultiway({ analog: true })
```
